### PR TITLE
Fix Null issues and update typo

### DIFF
--- a/pages/[address].js
+++ b/pages/[address].js
@@ -30,15 +30,15 @@ const Collection = () => {
     )
     col.floors = {}
     col.floors.openSea = {
-      floorPrice: floors.data.openSea.floorPrice || col.floorAsk.price,
+      floorPrice: floors.data.openSea.floorPrice || 0,
     }
     col.floors.looksRare = {
-      floorPrice: floors.data.looksRare.floorPrice || col.floorAsk.price,
+      floorPrice: floors.data.looksRare.floorPrice || 0,
     }
 
     const x2y2 = await axios.get(`/api/x2y2?contractAddress=${address}`)
     col.floors.x2y2 = {
-      floorPrice: x2y2.data && ethers.utils.formatEther(x2y2.data),
+      floorPrice: x2y2.data ? ethers.utils.formatEther(x2y2.data) : 0,
     }
     setCollection(col)
     setLoading(false)

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,10 +34,10 @@ const Home = () => {
         )
         nft.floors = {}
         nft.floors.openSea = {
-          floorPrice: floors.data.openSea.floorPrice || nft.floorAskPrice,
+          floorPrice: floors.data.openSea.floorPrice || 0,
         }
         nft.floors.looksRare = {
-          floorPrice: floors.data.looksRare.floorPrice || nft.floorAskPrice,
+          floorPrice: floors.data.looksRare.floorPrice || 0,
         }
         nft.floors.x2y2 = { floorPrice: null }
         return nft
@@ -51,7 +51,7 @@ const Home = () => {
         `/api/x2y2?contractAddress=${nft.primaryContract}`
       )
       nft.floors.x2y2 = {
-        floorPrice: x2y2.data && ethers.utils.formatEther(x2y2.data),
+        floorPrice: x2y2.data ? ethers.utils.formatEther(x2y2.data) : 0,
       }
     }
     setCollections(top20)
@@ -87,7 +87,7 @@ const Home = () => {
                 />
                 <div className='flex flex-col text-lg font-light tracking-wide w-32 gap-2'>
                   <div className='flex items-center justify-between gap-4'>
-                    {nft.floors.looksRare.floorPrice ? (
+                    {nft.floors.openSea.floorPrice ? (
                       cutNumber(
                         nft.floors.openSea.floorPrice.toLocaleString(
                           'fullwide',


### PR DESCRIPTION
The OpenSea price was wrong because it was pointing to the LooksRare NFT floor price.

I also proposed a fix for the Null errors. If the value is set to 0, then the NFT floor price will be stuck 'loading'. I think this would be fine because majority of the time when the NFT floor prices are Null, it means that the exchange doesn't have the NFT listed.

A different approach would be to check if the value is null in before this line of code since the 'toLocaleString' is erroring it out.

                  {cutNumber(
                    collection.floors.openSea.floorPrice.toLocaleString(
                      'fullwide',
                      {
                        useGrouping: false,
                      }
                    ),
                    3
                  )}